### PR TITLE
Fix braces in FOptionContainer.cpp

### DIFF
--- a/src/FOptionContainer.cpp
+++ b/src/FOptionContainer.cpp
@@ -336,7 +336,8 @@ bool FOptionContainer::read(const char *filename)
 					s[i] = (rand() % 26) + 'A';
 				}
 				mitm_magic = s;
-			if (findoptionS("onlymitmsslgrey") == "on") 
+			}
+			if (findoptionS("onlymitmsslgrey") == "on") {
 				only_mitm_ssl_grey = true;
 			} else {	
 				only_mitm_ssl_grey = false;


### PR DESCRIPTION
only_mitm_ssl_grey is set to false if option "mitmkey" is set correct in the filter config. It should be set false if the option "onlymitmsslgrey" is off or not defined.