### PR TITLE
Support of one log file by e2g instance

### DIFF
--- a/configs/e2guardian.conf.in
+++ b/configs/e2guardian.conf.in
@@ -56,6 +56,10 @@ logfileformat = 1
 # at the defined or built-in "loglocation"
 #logsyslog = off
 
+#Suffix to append to program name when logging through syslog
+# Default is the e2Guardian instance number
+#namesuffix = $z
+
 # Log file location
 # 
 # Defines the log directory and filename.

--- a/src/OptionContainer.cpp
+++ b/src/OptionContainer.cpp
@@ -143,6 +143,9 @@ bool OptionContainer::read(const char *filename, int type)
 
 			if (findoptionS("logsyslog") == "on") {
 				log_syslog = true;
+        if ((name_suffix = findoptionS("namesuffix")) == "") {
+          name_suffix = "";
+        }
 			} else 	if ((log_location = findoptionS("loglocation")) == "") {
 				log_location = __LOGLOCATION;
 				log_location += "/access.log";

--- a/src/OptionContainer.hpp
+++ b/src/OptionContainer.hpp
@@ -132,6 +132,7 @@ class OptionContainer
     bool no_daemon;
     bool no_logger;
     bool log_syslog;
+    std::string name_suffix;
     unsigned int max_logitem_length;
     bool anonymise_logs;
     bool log_ad_blocks;

--- a/src/e2guardian.cpp
+++ b/src/e2guardian.cpp
@@ -94,10 +94,11 @@ int main(int argc, char *argv[])
     bool needreset = false;
     bool total_block_list = false;
     std::string configfile(__CONFFILE);
+    std::string prog_name("e2guardian");
     srand(time(NULL));
     int rc;
 
-    openlog("e2guardian", LOG_PID | LOG_CONS, LOG_USER);
+    openlog(prog_name.c_str(), LOG_PID | LOG_CONS, LOG_USER);
 
 #ifdef DGDEBUG
     std::cout << "Running in debug mode..." << std::endl;
@@ -204,6 +205,12 @@ int main(int argc, char *argv[])
     }
 
     read_config(configfile.c_str(), 2);
+
+    if ( ! o.name_suffix.empty() ) {
+      prog_name += o.name_suffix;
+      closelog();
+      openlog(prog_name.c_str(), LOG_PID | LOG_CONS, LOG_USER);
+    }
 
     if (total_block_list && !o.readinStdin()) {
         syslog(LOG_ERR, "%s", "Error on reading total_block_list");


### PR DESCRIPTION
The goad of this patch is to have one log file by instance if you use syslog.

You add namesuffix  on you instance configuration file and e2guardian will write logs for this instance
in a logfile named e2guardian<namesuffix>.*.log

Signed-off-by: Philippe Caseiro <pcaseiro@cadoles.com>