### PR TITLE
e2guardian -g causes segfault #163

### DIFF
--- a/src/ListContainer.cpp
+++ b/src/ListContainer.cpp
@@ -1746,10 +1746,16 @@ time_t getFileDate(const char *filename)
     struct stat status;
     int rc = stat(filename, &status);
     if (rc != 0) {
-        if (errno == ENOENT)
+        if (errno == ENOENT) {
             return 0;
-        else
+        }
+        // If there are permission problems, just reload the file -Chris Nighswonger
+        if (errno == EACCES) {
+            return 0;
+        }
+        else {
             throw std::runtime_error(strerror(errno));
+        }
     }
     return status.st_mtime;
 }


### PR DESCRIPTION
This patch fixes the segfault caused by permission issues encountered
during a gentle reload of list files. It does this by adding a
condition to handle a stat return errno of EACCES by causing the
list to be reloaded. This should not result in any noticable
performance issues that I can see, although I have not benchmarked
it to see.