### PR TITLE
Improvements in feedback from realitycheck routines

### DIFF
--- a/configs/e2guardian.conf.in
+++ b/configs/e2guardian.conf.in
@@ -590,6 +590,8 @@ preforkchildren = 10
 # sets the maximum number of processes to have doing nothing.
 # When this many are spare it will cull some of them.
 # On large sites you might want to try 64.
+# Note:	This value must be greater than minchildren, but
+# 	less than maxchildren.
 maxsparechildren = 32
 
 

--- a/src/FOptionContainer.cpp
+++ b/src/FOptionContainer.cpp
@@ -2051,7 +2051,7 @@ std::string FOptionContainer::findoptionS(const char *option)
     return "";
 }
 
-bool FOptionContainer::realitycheck(int l, int minl, int maxl, const char *emessage)
+bool FOptionContainer::realitycheck(long int l, long int minl, long int maxl, const char *emessage)
 {
     // realitycheck checks a String for certain expected criteria
     // so we can spot problems in the conf files easier
@@ -2060,11 +2060,9 @@ bool FOptionContainer::realitycheck(int l, int minl, int maxl, const char *emess
             // when called we have not detached from
             // the console so we can write back an
             // error
-
-            std::cerr << "Config problem; check allowed values for " << emessage << std::endl;
+            std::cerr << "Config problem: " << emessage << " set to " << l << "; Value must be greater than " << minl << " and less than " << maxl << "." << std::endl;
         }
-        syslog(LOG_ERR, "Config problem; check allowed values for %s", emessage);
-
+        syslog(LOG_ERR, "Config problem %s set to %lu; Value must be greater than %lu and less than %lu.", emessage, l, minl, maxl);
         return false;
     }
     return true;

--- a/src/FOptionContainer.hpp
+++ b/src/FOptionContainer.hpp
@@ -474,7 +474,7 @@ class FOptionContainer
 
     int findoptionI(const char *option);
     std::string findoptionS(const char *option);
-    bool realitycheck(int l, int minl, int maxl, const char *emessage);
+    bool realitycheck(long int l, long int minl, long int maxl, const char *emessage);
     int inRegExpURLList(String &url, std::deque<RegExp> &list_comp, std::deque<unsigned int> &list_ref, unsigned int list);
 
     char *inURLList(String &url, unsigned int list, bool doblanket = false, bool ip = false, bool ssl = false);

--- a/src/OptionContainer.cpp
+++ b/src/OptionContainer.cpp
@@ -302,10 +302,6 @@ bool OptionContainer::read(const char *filename, int type)
         } // check its a reasonable value
         maxspare_children = findoptionI("maxsparechildren");
         if (!realitycheck(maxspare_children, min_children, max_children, "maxsparechildren")) {
-    	   if (!is_daemonised) {
-                    std::cerr << "maxsparechildren must greater than minchildren and can not be greater than maxchildren" << std::endl;
-           }
-           syslog(LOG_ERR, "%s", "maxsparechildren must greater than minchildren and can not be greater than maxchildren");
            return false;
         } // check its a reasonable value
         prefork_children = findoptionI("preforkchildren");
@@ -1290,9 +1286,9 @@ bool OptionContainer::realitycheck(long int l, long int minl, long int maxl, con
             // the console so we can write back an
             // error
 
-            std::cerr << "Config problem; check allowed values for " << emessage << std::endl;
+            std::cerr << "Config problem: " << emessage << " set to " << l << "; Value must be greater than " << minl << " and less than " << maxl << "." << std::endl;
         }
-        syslog(LOG_ERR, "Config problem; check allowed values for %s", emessage);
+        syslog(LOG_ERR, "Config problem %s set to %lu; Value must be greater than %lu and less than %lu.", emessage, l, minl, maxl);
         return false;
     }
     return true;


### PR DESCRIPTION
`OptionContainer::realitycheck` and `FOptionContainer::realitycheck` to
make them a little more useful to the sysadmin.

This patch also makes the type declarations for the parameters
passed in to both routines consistent.

It also updates the comments in e2guardian.conf to be more helpful
when selecting values for `maxsparechildren`