### PR TITLE
add missing return for bool functions

### DIFF
--- a/src/BaseSocket.cpp
+++ b/src/BaseSocket.cpp
@@ -465,6 +465,7 @@ bool BaseSocket::writeString(const char *line) //throw(std::exception)
         return false;
 //        throw std::runtime_error(std::string("Can't write to socket: ") + strerror(errno));
     }
+    return true;
 }
 
 // write data to socket - throws exception on failure, can be told to break on config reloads

--- a/src/DataBuffer.cpp
+++ b/src/DataBuffer.cpp
@@ -304,9 +304,11 @@ bool DataBuffer::out(Socket *sock) //throw(std::exception)
            //     throw std::exception();
         }
 #ifdef DGDEBUG
-        std::cout << "Sent " << buffer_length - bytesalreadysent << " bytes from RAM (" << buffer_length  << " Line: " << __LINE__ << " Function: " << __func__ << std::endl;
+        std::cout << "Sent " << buffer_length - bytesalreadysent << " bytes from RAM (" << buffer_length  << ") Line: " << __LINE__ << " Function: " << __func__ << std::endl;
 #endif
+     return true;
     }
+   return true;
 }
 
 // zlib decompression


### PR DESCRIPTION
on FreeBSD e2guardian crashes with Illegal instruction message when bool functions return UNDEFINED or anything different from true or false

https://github.com/e2guardian/e2guardian/issues/222