### PR TITLE
Fix content scanner (clamdscan)

### DIFF
--- a/src/OptionContainer.cpp
+++ b/src/OptionContainer.cpp
@@ -406,10 +406,11 @@ bool OptionContainer::read(std::string& filename, int type)
                 return false;
             }
 
-            content_scanner_timeout = findoptionI("contentscannertimeout");
-            if (!realitycheck(content_scanner_timeout, 1, 0, "contentscannertimeout")) {
+            content_scanner_timeout_sec = findoptionI("contentscannertimeout");
+            if (!realitycheck(content_scanner_timeout_sec, 1, 0, "contentscannertimeout")) {
                 return false;
             }
+            content_scanner_timeout = content_scanner_timeout_sec * 1000;
 
             if (findoptionS("scancleancache") == "off") {
                 scan_clean_cache = false;

--- a/src/OptionContainer.hpp
+++ b/src/OptionContainer.hpp
@@ -172,6 +172,7 @@ class OptionContainer
     int initial_trickle_delay;
     int trickle_delay;
     int content_scanner_timeout;
+    int content_scanner_timeout_sec;
 
     HTMLTemplate html_template;
     ListContainer filter_groups_list;

--- a/src/UDSocket.cpp
+++ b/src/UDSocket.cpp
@@ -38,6 +38,8 @@
 UDSocket::UDSocket()
 {
     sck = socket(PF_UNIX, SOCK_STREAM, 0);
+    infds[0].fd = sck;
+    outfds[0].fd = sck;
     memset(&my_adr, 0, sizeof my_adr);
     memset(&peer_adr, 0, sizeof peer_adr);
     my_adr.sun_family = AF_UNIX;
@@ -73,6 +75,8 @@ void UDSocket::reset()
 {
     this->baseReset();
     sck = socket(PF_UNIX, SOCK_STREAM, 0);
+    infds[0].fd = sck;
+    outfds[0].fd = sck;
     memset(&my_adr, 0, sizeof my_adr);
     memset(&peer_adr, 0, sizeof peer_adr);
     my_adr.sun_family = AF_UNIX;


### PR DESCRIPTION
Fixes contentscanner timeout (was 60ms instead of 60s) and unix domain socket communication (broken clamdscan, other contentscanners are probably broken as well). Fixes #224.

This is based on @philipianpearce's retryfix branch (commit 8e4b896). I couldn't find a development branch that looks up to date (master, develop, v4develop all seem to be ancient, even the v4.1 tag seems to be out of line). So I based this PR on the `header` branch which seems to be the most current common ancestor. Let me know if I should rebase to a different branch.
