### PR TITLE
Fix syntax error in Makefile.am

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -114,7 +114,7 @@ e2guardian_SOURCES = String.cpp String.hpp \
                        ConfigVar.cpp ConfigVar.hpp \
                        ContentScanner.cpp ContentScanner.hpp \
 		       SocketArray.cpp SocketArray.hpp \
-                       e2guardian.cpp \ Plugin.hpp \
+                       e2guardian.cpp Plugin.hpp \
 		       LOptionContainer.cpp LOptionContainer.hpp \
                        CertificateAuthority.cpp CertificateAuthority.hpp \
 		       Queue.hpp \


### PR DESCRIPTION
The errant backslash causes 'make dist' to fail.