### PR TITLE
Fix type of ttg

### DIFF
--- a/src/ConnectionHandler.cpp
+++ b/src/ConnectionHandler.cpp
@@ -51,7 +51,7 @@
 // GLOBALS
 extern OptionContainer o;
 extern bool is_daemonised;
-extern std::atomic<int> ttg;
+extern std::atomic<bool> ttg;
 //bool reloadconfig = false;
 // If a specific debug line is needed
 thread_local int dbgPeerPort = 0;


### PR DESCRIPTION
This completely broke e2guardian when compiled with Fedora CXXFLAGS.