### PR TITLE
workaround or fix for dnsauthredirect url

### DIFF
--- a/src/HTTPHeader.cpp
+++ b/src/HTTPHeader.cpp
@@ -1244,6 +1244,15 @@ String HTTPHeader::getUrl(bool withport, bool isssl)
     bool https = false;
     if (!mitm)
         mitm = isssl;
+
+#ifdef DGDEBUG
+     std::cerr << thread_id << "HTTPHeader size: " << header.size() << std::endl; 
+#endif
+    String emptyheader = "CONNECT https://www.google.com:443/ HTML/1.0";
+    if (header.size() == 0) {
+    	return emptyheader;
+    }
+	
     String hostname;
     String userpassword;
     String answer(header.front().after(" "));


### PR DESCRIPTION
#374 
possible workaround for segfault error while using dnsauth and redirect url.

returning a url to h.geturl() user is correctly forwarded to auth page with correct url using mitm

Without mitm, it returns expected Secure connection failed.

Not sure if this hack will break something but at least on my tests, dnsauth is now working fine.

