### PR TITLE
Fixes compiler error caused by extra brace

### DIFF
--- a/src/FOptionContainer.cpp
+++ b/src/FOptionContainer.cpp
@@ -84,23 +84,22 @@ void FOptionContainer::reset()
     resetJustListData();
 }
 
-    void FOptionContainer::resetJustListData()
-    {
-        if (!(group_mode == 1))
-            return;
-        if (banned_phrase_flag)
-            o.lm.deRefList(banned_phrase_list);
+void FOptionContainer::resetJustListData()
+{
+    if (!(group_mode == 1))
+        return;
+    if (banned_phrase_flag)
+        o.lm.deRefList(banned_phrase_list);
 
-        banned_phrase_flag = false;
-        content_regexp_flag = false;
-        ssl_mitm = false;
+    banned_phrase_flag = false;
+    content_regexp_flag = false;
+    ssl_mitm = false;
 
-        banned_phrase_list_index.clear();
+    banned_phrase_list_index.clear();
 
-        //	conffile.clear();
+    //	conffile.clear();
 
-        content_regexp_list_comp.clear();
-    }
+    content_regexp_list_comp.clear();
     content_regexp_list_rep.clear();
 }
 


### PR DESCRIPTION
Fixes a compiler error that is caused by an extra brace in the resetJustListData function definition in FOptionContainer.cpp