### PR TITLE
Allow the ip authplugin to use the X-Client-IP header when using ICAP

### DIFF
--- a/src/HTTPHeader.cpp
+++ b/src/HTTPHeader.cpp
@@ -1895,6 +1895,10 @@ void HTTPHeader::setClientIP(String &ip) {
     s_clientip = ip.toCharArray();
 }
 
+String HTTPHeader::getClientIP() {
+    return s_clientip;
+}
+
 void HTTPHeader::setDirect() {
     isdirect = true;
 }

--- a/src/HTTPHeader.hpp
+++ b/src/HTTPHeader.hpp
@@ -50,6 +50,7 @@ class HTTPHeader
     bool in(Socket *sock, bool allowpersistent = false );
 
     void setClientIP(String &ip);
+    String getClientIP();
 
     String stringHeader();  // output header as a String (used by ICAP)
 

--- a/src/ICAPHeader.cpp
+++ b/src/ICAPHeader.cpp
@@ -613,6 +613,7 @@ bool  ICAPHeader::errorResponse(Socket &peerconn, String &res_header, String &re
 
 void ICAPHeader::setClientIP(String &ip) {
     clientip = ip;
+    HTTPrequest.setClientIP(ip);
 }
 
 bool ICAPHeader::in(Socket *sock, bool allowpersistent)

--- a/src/authplugins/ip.cpp
+++ b/src/authplugins/ip.cpp
@@ -163,6 +163,9 @@ int ipinstance::identify(Socket &peercon, Socket &proxycon, HTTPHeader &h, std::
     if (use_xforwardedfor == 1) {
         // grab the X-Forwarded-For IP if available
         string = h.getXForwardedForIP();
+        // or try the client IP from the header
+        if (string.length() == 0)
+            string = h.getClientIP();
         // otherwise, grab the IP directly from the client connection
         if (string.length() == 0)
             string = peercon.getPeerIP();


### PR DESCRIPTION
When running e2guardian in ICAP mode the `ip` authplugin does not work since it gets the IP address of the squid proxy, not the client IP passed through the X-Client-IP header (this is the ICAP equivalent of the X-Forwarded-For header).

This might be a poor way of getting this to work, but it basically pushes the clientip from the ICAPHeader to the HTTPHeader passed to the plugin.