### PR TITLE
Reenable content regexp

### DIFF
--- a/src/FOptionContainer.cpp
+++ b/src/FOptionContainer.cpp
@@ -676,7 +676,12 @@ bool FOptionContainer::read(const char *filename) {
                     }
                 }
             }
-
+	    std::string content_regexp_list_location(findoptionS("contentregexplist"));
+	    unsigned int content_regexp_list;
+            if (!LMeta.readRegExReplacementFile(content_regexp_list_location.c_str(), "contentregexplist", content_regexp_list, content_regexp_list_rep, content_regexp_list_comp)) {
+                return false;
+            } // content replacement regular expressions
+	    content_regexp_flag = true;
 
 #ifdef DGDEBUG
         std::cerr << thread_id << "Lists in memory" << std::endl;

--- a/src/ListMeta.hpp
+++ b/src/ListMeta.hpp
@@ -91,6 +91,9 @@ class ListMeta
 
    bool readFile(const char *filename, unsigned int *whichlist, bool sortsw, const char *listname,bool isip = false);
 
+   bool readRegExReplacementFile(const char *filename, const char *listname, unsigned int &listid,
+       std::deque<String> &list_rep, std::deque<RegExp> &list_comp);
+
 private:
 
     char *inURLList(String &url, unsigned int list,  String &lastcategory, bool &site_wild);
@@ -108,8 +111,6 @@ bool regExp(String &line, std::deque<RegExp> &regexp_list, std::deque<String> &r
         std::deque<RegExp> &list_comp, std::deque<String> &list_source, std::deque<unsigned int> &list_ref);
     bool compileRegExMatchFile(unsigned int list, std::deque<RegExp> &list_comp,
         std::deque<String> &list_source, std::deque<unsigned int> &list_ref);
-    bool readRegExReplacementFile(const char *filename, const char *listname, unsigned int &listid,
-        std::deque<String> &list_rep, std::deque<RegExp> &list_comp);
 
 };
 

--- a/src/RegExp.cpp
+++ b/src/RegExp.cpp
@@ -172,9 +172,9 @@ bool RegExp::match(const char *text, RegResult &rs)
     if (regexec(&reg, pos, num_sub_expressions + 1, pmatch, 0)) { // run regexdelete[]pmatch;
         delete[] pmatch;
         rs.imatched = false;
-        //        #ifdef DGDEBUG
-        //            std::cerr << thread_id << "no match for:" << searchstring << std::endl;
-        //        #endif
+#ifdef REDEBUG
+            std::cerr << thread_id << "no match for:" << searchstring << std::endl;
+#endif
         return false; // if no match
     }
     size_t matchlen;


### PR DESCRIPTION
Add back code from v4.1 to read contentregexplist into the lists used by the DataBuffer code.