### PR TITLE
Fix TRANSLATION KEY 0 MISSING messages

### DIFF
--- a/data/languages/messages_master
+++ b/data/languages/messages_master
@@ -4,7 +4,7 @@
 # Then run ./update_messages to merge the new messages into all language
 #     files. '# needs translation' will be appended to new lines.
 
-# Messages 0-4999 are reserved for standard use.
+# Messages 1-4999 are reserved for standard use.
 # Please use numbers above 5000 for localy defined messages
 
 "1","Access Denied"

--- a/src/StoryBoard.cpp
+++ b/src/StoryBoard.cpp
@@ -637,7 +637,10 @@ bool StoryBoard::runFunct(unsigned int fID, NaughtyFilter &cm) {
                     cm.isGrey = false;
                     cm.isBlocked = false;
                     //cm.exceptionreason = o.language_list.getTranslation(cm.message_no);
-                    cm.whatIsNaughty = o.language_list.getTranslation(cm.message_no) + cm.lastmatch;
+                    if (cm.message_no > 0)
+                        cm.whatIsNaughty = o.language_list.getTranslation(cm.message_no) + cm.lastmatch;
+                    else
+                        cm.whatIsNaughty = cm.lastmatch;
                     if (cm.log_message_no == 0)
                         cm.whatIsNaughtyLog = cm.whatIsNaughty;
                     else


### PR DESCRIPTION
Given how  message no 0 is used, it is not supposed to have a translation. So I suggest that we do not print a translation error for it. Otherwise, I see a lot of such translation errors in access logs for, say, the extensions listed in exceptionextensionlist, because exceptionextensionlist does not have a messageno specified in f1.conf.

Also, I suggest we fix the documentation in messages_master accordingly.