### PR TITLE
Clarification of the proxy ports for https mitm

### DIFF
--- a/notes/ssl_mitm
+++ b/notes/ssl_mitm
@@ -66,3 +66,7 @@ To set up MITM:
    Set sslmitm = on in e2guardianfx.conf
 
    Load my_rootCA certificate on each browser.
+
+   Set both http proxy and https proxy to the same port defined in the option
+   filterports, if you use e2guardian as direct proxy. transparenthttpsport
+   is only for transparent proxying.

--- a/notes/ssl_mitm
+++ b/notes/ssl_mitm
@@ -67,6 +67,7 @@ To set up MITM:
 
    Load my_rootCA certificate on each browser.
 
-   Set both http proxy and https proxy to the same port defined in the option
-   filterports, if you use e2guardian as direct proxy. transparenthttpsport
-   is only for transparent proxying.
+   If you want to use e2guardian as direct proxy, you will have to configure your
+   browsers to use the port defined in filterports for http and https connections.
+   Don't use the port from the option transparenthttpsport. That is not suited for
+   direct proxying.


### PR DESCRIPTION
Hello,
Thank you for your work on e2guardian.
I had some trouble with the proxysettings in my browser until I understood, that I had to use the http proxyport for https, too. I added a short comment to the note about http mitm to clarify this issue. Maybe it helps other people.

Kind regards,
Ulrich