### PR TITLE
Setting the flag if conn destination is known

### DIFF
--- a/src/ConnectionHandler.cpp
+++ b/src/ConnectionHandler.cpp
@@ -3658,6 +3658,7 @@ getsockopt(peerconn.getFD(), SOL_IP, SO_ORIGINAL_DST, &origaddr, &origaddrlen ) 
         char res[INET_ADDRSTRLEN];
         checkme.orig_ip = inet_ntop(AF_INET,&origaddr.sin_addr,res,sizeof(res));
         checkme.orig_port = ntohs(origaddr.sin_port);
+	checkme.got_orig_ip = true;
         return true;
     }
 #else   // TODO: BSD code needs adding - depends on firewall being used


### PR DESCRIPTION
Without this, e2guardian replies rst if you try to visit https://some.ip.address (i.e. https://1.1.1.1)