### PR TITLE
Fix c string conversion compiler error

### DIFF
--- a/src/ConnectionHandler.cpp
+++ b/src/ConnectionHandler.cpp
@@ -1074,7 +1074,7 @@ int ConnectionHandler::handleConnection(Socket &peerconn, String &ip, bool ismit
                 temp += "Server: ";
                 temp += o.server_name;
                 temp += "<br>";
-                peerconn.writeString(temp);
+                peerconn.writeString(temp.c_str());
                 peerconn.writeString("</BODY></HTML>\n");
                 proxysock.close(); // close connection to proxy
                 break;


### PR DESCRIPTION
The code doesn't compile due to a compiler error. "Cannot convert from const char * to string." Using c_str() will fix this.