### PR TITLE
Fix default size of maxcontentramcachescansize option in configs/e2guardian.conf.in

### DIFF
--- a/configs/e2guardian.conf.in
+++ b/configs/e2guardian.conf.in
@@ -1033,7 +1033,7 @@ weightedphrasemode = 2
 # The size is in Kibibytes - eg 2048 = 2Mb
 # default 2048
 
-#maxcontentramcachescansize = 2000
+#maxcontentramcachescansize = 2048
 #
 # Max content ram cache scan size
 # This is only used if you use a content scanner plugin such as AV
@@ -1043,7 +1043,7 @@ weightedphrasemode = 2
 # The size is in Kibibytes - eg 10240 = 10Mb
 # use 0 to set it to maxcontentfilecachescansize
 # This option may be ignored by the configured download manager.
-# default 2000
+# default 2048
 
 #maxcontentfilecachescansize = 20000
 #

--- a/src/OptionContainer.cpp
+++ b/src/OptionContainer.cpp
@@ -437,7 +437,7 @@ bool OptionContainer::read(std::string &filename, int type) {
         max_content_filter_size *= 1024;
 
         if(findoptionS("maxcontentramcachescansize").empty()) {
-            max_content_ramcache_scan_size = 2000;
+            max_content_ramcache_scan_size = 2048;
         } else {
             max_content_ramcache_scan_size = findoptionI("maxcontentramcachescansize");
         }

--- a/src/OptionContainer.cpp
+++ b/src/OptionContainer.cpp
@@ -437,7 +437,7 @@ bool OptionContainer::read(std::string &filename, int type) {
         max_content_filter_size *= 1024;
 
         if(findoptionS("maxcontentramcachescansize").empty()) {
-            max_content_filecache_scan_size = 2000;
+            max_content_ramcache_scan_size = 2000;
         } else {
             max_content_ramcache_scan_size = findoptionI("maxcontentramcachescansize");
         }


### PR DESCRIPTION
While looking at Debian bug report  https://bugs.debian.org/998430 I spotted two flaws in the upstream code.

First flaw is that maxcontentramcachescansize's default value never gets initialized (first patch in this PR).

Second flaw is that if it would get initialized correctly, it would get initialized to a value that is lower than maxcontentfiltersize. However, for maxcontentfiltersize the documentation says:

```
# The [maxcontentfiltersize] value must not be higher than maxcontentramcachescansize
```

However, maxcontentfiltersize is 2048 by default, whereas maxcontentramcachescansize is only 2000 by default.