### PR TITLE
Add OPENSSL_CFLAGS/_LIBS for openssl11 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -536,9 +536,10 @@ else
 	AC_MSG_RESULT(yes)
 	sslmitm=true
 	SSLMITMSUPPORT=""
-	LIBS="${LIBS} -lssl -lcrypto"
 	AC_DEFINE([__SSLMITM],[],[Define to enable SSL MITM ])
 	PKG_CHECK_MODULES([OPENSSL],[ openssl >= 1.0.1])
+	CXXFLAGS="${CXXFLAGS} ${OPENSSL_CFLAGS}"
+	LIBS="${LIBS} ${OPENSSL_LIBS}"
 fi],
 [
 	AC_MSG_RESULT(no)


### PR DESCRIPTION
When compiling for EL7 we must use the openssl11 package from EPEL.  This puts things in non-standard locations as reported by the openssl11 pkgconfig module.  However, e2g doesn't use them.  This patch fixes that.