### PR TITLE
Fix build error AM_INIT_AUTOMAKE expanded multiple times v5.3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,10 +6,9 @@ AC_DEFINE([FD_SETSIZE_OVERIDE],[""],[Define to allow DANS_MAXFD to exceed FD_SET
 
 AC_PREREQ(2.57)
 AC_INIT(e2guardian, 5.3.4)
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_HEADERS([dgconfig.h])
 AC_CONFIG_MACRO_DIR([m4])
-AM_INIT_AUTOMAKE([subdir-objects])
 
 AC_CACHE_LOAD
 


### PR DESCRIPTION
When building e2guardian through the Arch Linux AUR, I get this error:

```
configure.ac:12: error: AM_INIT_AUTOMAKE expanded multiple times
/usr/share/aclocal-1.16/init.m4:29: AM_INIT_AUTOMAKE is expanded from...
configure.ac:9: the top level
/usr/share/aclocal-1.16/init.m4:29: AM_INIT_AUTOMAKE is expanded from...
configure.ac:12: the top level
autom4te: error: /usr/bin/m4 failed with exit status: 1
aclocal: error: autom4te failed with exit status: 1
```

Simple fix.  The AUR is still on version 5.3.4; this would fix that version.