### PR TITLE
Fix build error AM_INIT_AUTOMAKE expanded multiple times v5.5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,10 +5,9 @@
 
 AC_PREREQ(2.63)
 AC_INIT([e2guardian],[5.5.2])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_HEADERS([e2config.h])
 AC_CONFIG_MACRO_DIR([m4])
-AM_INIT_AUTOMAKE([subdir-objects])
 
 AC_CACHE_LOAD
 


### PR DESCRIPTION
When building e2guardian through the Arch Linux AUR, I get this error:

```
configure.ac:12: error: AM_INIT_AUTOMAKE expanded multiple times
/usr/share/aclocal-1.16/init.m4:29: AM_INIT_AUTOMAKE is expanded from...
configure.ac:9: the top level
/usr/share/aclocal-1.16/init.m4:29: AM_INIT_AUTOMAKE is expanded from...
configure.ac:12: the top level
autom4te: error: /usr/bin/m4 failed with exit status: 1
aclocal: error: autom4te failed with exit status: 1
```

Simple fix.  The AUR is still on version 5.3.4, but this will allow it to go to 5.5 when it's released.