### PR TITLE
Upgrade to Debian12 in CI/CD

### DIFF
--- a/gitlabci/armdebian.yml
+++ b/gitlabci/armdebian.yml
@@ -37,7 +37,7 @@ package:debarm:
   script:
     - source $CI_PROJECT_DIR/scripts/debian_package/variables
     - apt update
-    - apt install -y curl git lsb-release binutils curl ca-certificates util-linux binutils libpcre3 lbssl1.3
+    - apt install -y curl git lsb-release binutils curl ca-certificates util-linux binutils libpcre3 lbssl3
     - echo $VFULL
     - VERSION=`lsb_release -cs`
     - SIZE=`stat -c %s ${PACKDST}/data` && echo $SIZE && sed -i "s/Installed-Size:.*$/Installed-Size:\ $SIZE/g" ${PACKDST}/control/control

--- a/gitlabci/armdebian.yml
+++ b/gitlabci/armdebian.yml
@@ -1,6 +1,6 @@
 build:arm:
   stage: build
-  image: debian:bullseye
+  image: debian:bookworm-slim
   artifacts:
    expire_in: 30 minutes
    paths:
@@ -24,7 +24,7 @@ build:arm:
 
 package:debarm:
   stage: create-package
-  image: debian:bullseye
+  image: debian:bookworm-slim
   dependencies:
     - build:arm
   artifacts:
@@ -59,7 +59,7 @@ package:debarm:
 
 test:debianarm:
   stage: test-publish
-  image: debian:bullseye
+  image: debian:bookworm-slim
   dependencies:
     - package:debarm
   artifacts:

--- a/gitlabci/armdebian.yml
+++ b/gitlabci/armdebian.yml
@@ -37,7 +37,7 @@ package:debarm:
   script:
     - source $CI_PROJECT_DIR/scripts/debian_package/variables
     - apt update
-    - apt install -y curl git lsb-release binutils curl ca-certificates util-linux binutils libpcre3 
+    - apt install -y curl git lsb-release binutils curl ca-certificates util-linux binutils libpcre3 lbssl1.3
     - echo $VFULL
     - VERSION=`lsb_release -cs`
     - SIZE=`stat -c %s ${PACKDST}/data` && echo $SIZE && sed -i "s/Installed-Size:.*$/Installed-Size:\ $SIZE/g" ${PACKDST}/control/control

--- a/gitlabci/armdebian.yml
+++ b/gitlabci/armdebian.yml
@@ -37,7 +37,7 @@ package:debarm:
   script:
     - source $CI_PROJECT_DIR/scripts/debian_package/variables
     - apt update
-    - apt install -y curl git lsb-release binutils
+    - apt install -y curl git lsb-release binutils curl ca-certificates util-linux binutils libpcre3 
     - echo $VFULL
     - VERSION=`lsb_release -cs`
     - SIZE=`stat -c %s ${PACKDST}/data` && echo $SIZE && sed -i "s/Installed-Size:.*$/Installed-Size:\ $SIZE/g" ${PACKDST}/control/control

--- a/gitlabci/armdebian.yml
+++ b/gitlabci/armdebian.yml
@@ -28,6 +28,7 @@ package:debarm:
   dependencies:
     - build:arm
   artifacts:
+   expire_in: 30 minutes
    paths:
     - $CI_PROJECT_DIR   
   variables:
@@ -63,6 +64,7 @@ test:debianarm:
   dependencies:
     - package:debarm
   artifacts:
+   expire_in: 30 minutes
    name: builddebian
    paths:
     - $CI_PROJECT_DIR 

--- a/gitlabci/armdebian.yml
+++ b/gitlabci/armdebian.yml
@@ -75,7 +75,7 @@ test:debianarm:
     - source $CI_PROJECT_DIR/scripts/debian_package/variables
     - echo $VFULL
     - apt update
-    - apt install -y openssl curl git lsb-release libevent-pthreads* libtommath* libpcre3 lbssl1.3 
+    - apt install -y openssl curl git lsb-release libevent-pthreads* libtommath* libpcre3 lbssl3 
     - VERSION=`lsb_release -cs`
     - cd ${PACKDST} && cd .. && dpkg -i e2"$OS"_package.deb 
     - sed -i "s/^#sslmitm.*$/sslmitm\ =\ on/" /etc/e2guardian/e2guardianf1.conf && sed -i "s/^#enablessl.*$/enablessl\ =\ on/" /etc/e2guardian/e2guardian.conf && sed -i "s/^RANDFILE\s*=\s*\\\$ENV/#RANDFILE\ =\ \$ENV/" /etc/ssl/openssl.cnf

--- a/gitlabci/armdebian.yml
+++ b/gitlabci/armdebian.yml
@@ -75,7 +75,7 @@ test:debianarm:
     - source $CI_PROJECT_DIR/scripts/debian_package/variables
     - echo $VFULL
     - apt update
-    - apt install -y openssl curl git lsb-release libevent-pthreads* libtommath* libpcre3 lbssl3 
+    - apt install -y openssl curl git lsb-release libevent-pthreads* libtommath* libpcre3 libssl3 
     - VERSION=`lsb_release -cs`
     - cd ${PACKDST} && cd .. && dpkg -i e2"$OS"_package.deb 
     - sed -i "s/^#sslmitm.*$/sslmitm\ =\ on/" /etc/e2guardian/e2guardianf1.conf && sed -i "s/^#enablessl.*$/enablessl\ =\ on/" /etc/e2guardian/e2guardian.conf && sed -i "s/^RANDFILE\s*=\s*\\\$ENV/#RANDFILE\ =\ \$ENV/" /etc/ssl/openssl.cnf

--- a/gitlabci/armdebian.yml
+++ b/gitlabci/armdebian.yml
@@ -13,7 +13,7 @@ build:arm:
    - apt update 
    - apt-get -y upgrade 
    - echo "deb-src http://deb.debian.org/debian bullseye main contrib non-free" >> /etc/apt/sources.list 
-   - apt-get install --no-upgrade --no-install-recommends --no-install-suggests -y curl unzip automake coreutils debianutils diffutils e2fsprogs findutils grep unzip ncurses-base libevent-pthreads-* libevent-dev ncurses-bin login sysvinit-utils tar libc6-dev libc-dev gcc g++ make dpkg-dev autotools-dev debhelper dh-autoreconf dpatch libclamav-dev libpcre3-dev zlib1g-dev pkg-config libssl-dev ca-certificates lsb-release inotify-tools curl 
+   - apt-get install --no-upgrade --no-install-recommends --no-install-suggests -y curl unzip automake coreutils debianutils diffutils e2fsprogs findutils grep unzip ncurses-base libevent-pthreads-* libevent-dev ncurses-bin login sysvinit-utils tar libc6-dev libc-dev gcc g++ make dpkg-dev autotools-dev debhelper dh-autoreconf libclamav-dev libpcre3-dev zlib1g-dev pkg-config libssl-dev ca-certificates lsb-release inotify-tools curl 
    - cd $CI_PROJECT_DIR && make clean  
    - ./autogen.sh
    - ./configure --host=arm-linux-gnueabihf --prefix=/usr --enable-clamd=yes --with-proxyuser=e2guardian --with-proxygroup=e2guardian --sysconfdir=/etc --localstatedir=/var --enable-icap=yes --enable-commandline=yes --enable-email=yes --enable-ntlm=yes --enable-pcre=yes --enable-sslmitm=yes 

--- a/gitlabci/armdebian.yml
+++ b/gitlabci/armdebian.yml
@@ -37,7 +37,7 @@ package:debarm:
   script:
     - source $CI_PROJECT_DIR/scripts/debian_package/variables
     - apt update
-    - apt install -y curl git lsb-release binutils curl ca-certificates util-linux binutils libpcre3 lbssl3
+    - apt install -y curl git lsb-release binutils curl ca-certificates util-linux binutils libpcre3 libssl3
     - echo $VFULL
     - VERSION=`lsb_release -cs`
     - SIZE=`stat -c %s ${PACKDST}/data` && echo $SIZE && sed -i "s/Installed-Size:.*$/Installed-Size:\ $SIZE/g" ${PACKDST}/control/control

--- a/gitlabci/armdebian.yml
+++ b/gitlabci/armdebian.yml
@@ -13,7 +13,7 @@ build:arm:
    - apt update 
    - apt-get -y upgrade 
    - echo "deb-src http://deb.debian.org/debian bullseye main contrib non-free" >> /etc/apt/sources.list 
-   - apt-get install --no-upgrade --no-install-recommends --no-install-suggests -y curl unzip automake coreutils debianutils diffutils e2fsprogs findutils grep unzip ncurses-base libevent-pthreads-* libevent-dev ncurses-bin login sysvinit-utils tar libc6-dev libc-dev gcc g++ make dpkg-dev autotools-dev debhelper dh-autoreconf dpatch libclamav-dev libpcre3-dev zlib1g-dev pkg-config libssl-dev libssl1.1 ca-certificates lsb-release inotify-tools curl 
+   - apt-get install --no-upgrade --no-install-recommends --no-install-suggests -y curl unzip automake coreutils debianutils diffutils e2fsprogs findutils grep unzip ncurses-base libevent-pthreads-* libevent-dev ncurses-bin login sysvinit-utils tar libc6-dev libc-dev gcc g++ make dpkg-dev autotools-dev debhelper dh-autoreconf dpatch libclamav-dev libpcre3-dev zlib1g-dev pkg-config libssl-dev ca-certificates lsb-release inotify-tools curl 
    - cd $CI_PROJECT_DIR && make clean  
    - ./autogen.sh
    - ./configure --host=arm-linux-gnueabihf --prefix=/usr --enable-clamd=yes --with-proxyuser=e2guardian --with-proxygroup=e2guardian --sysconfdir=/etc --localstatedir=/var --enable-icap=yes --enable-commandline=yes --enable-email=yes --enable-ntlm=yes --enable-pcre=yes --enable-sslmitm=yes 

--- a/gitlabci/armdebian.yml
+++ b/gitlabci/armdebian.yml
@@ -75,7 +75,7 @@ test:debianarm:
     - source $CI_PROJECT_DIR/scripts/debian_package/variables
     - echo $VFULL
     - apt update
-    - apt install -y openssl curl git lsb-release libevent-pthreads* libtommath* 
+    - apt install -y openssl curl git lsb-release libevent-pthreads* libtommath* libpcre3 lbssl1.3 
     - VERSION=`lsb_release -cs`
     - cd ${PACKDST} && cd .. && dpkg -i e2"$OS"_package.deb 
     - sed -i "s/^#sslmitm.*$/sslmitm\ =\ on/" /etc/e2guardian/e2guardianf1.conf && sed -i "s/^#enablessl.*$/enablessl\ =\ on/" /etc/e2guardian/e2guardian.conf && sed -i "s/^RANDFILE\s*=\s*\\\$ENV/#RANDFILE\ =\ \$ENV/" /etc/ssl/openssl.cnf

--- a/gitlabci/debianlatest.yml
+++ b/gitlabci/debianlatest.yml
@@ -64,7 +64,7 @@ test:debian:
     - source $CI_PROJECT_DIR/scripts/debian_package/variables
     - echo $VFULL
     - apt update
-    - apt install -y openssl curl git lsb-release libevent-pthreads* libtommath* 
+    - apt install -y openssl curl git lsb-release libevent-pthreads* libtommath* libpcre3 
     - VERSION=`lsb_release -cs`
     - cd ${PACKDST} && dpkg -i e2"$OS"_package.deb 
     - sed -i "s/^#sslmitm.*$/sslmitm\ =\ on/" /etc/e2guardian/e2guardianf1.conf && sed -i "s/^#enablessl.*$/enablessl\ =\ on/" /etc/e2guardian/e2guardian.conf && sed -i "s/^RANDFILE\s*=\s*\\\$ENV/#RANDFILE\ =\ \$ENV/" /etc/ssl/openssl.cnf

--- a/gitlabci/debianlatest.yml
+++ b/gitlabci/debianlatest.yml
@@ -13,7 +13,7 @@ build:debian:
     - apt install --no-install-recommends --no-install-suggests -y curl unzip base-files automake base-passwd
       bash coreutils dash debianutils diffutils dpkg e2fsprogs findutils grep gzip hostname ncurses-base
       libevent-pthreads-* libevent-dev ncurses-bin perl-base sed login sysvinit-utils tar bsdutils
-      mount util-linux libc6-dev libc-dev gcc g++ make dpkg-dev autotools-dev debhelper dh-autoreconf dpatch
+      mount util-linux libc6-dev libc-dev gcc g++ make dpkg-dev autotools-dev debhelper dh-autoreconf
       libclamav-dev libpcre3-dev zlib1g-dev pkg-config libssl-dev git ca-certificates lsb-release
     - cd $CI_PROJECT_DIR && ./autogen.sh && ./configure  '--prefix=/usr' '--enable-clamd=yes' '--with-proxyuser=e2guardian' '--with-proxygroup=e2guardian' '--sysconfdir=/etc' '--localstatedir=/var' '--enable-icap=yes' '--enable-commandline=yes' '--enable-email=yes' '--enable-ntlm=yes' '--mandir=${prefix}/share/man' '--infodir=${prefix}/share/info' '--enable-pcre=yes' '--enable-sslmitm=yes' 'CPPFLAGS=-mno-sse2 -g -O2'
     - make

--- a/gitlabci/debianlatest.yml
+++ b/gitlabci/debianlatest.yml
@@ -4,7 +4,7 @@ build:debian:
    expire_in: 30 minutes
    paths:
     - $CI_PROJECT_DIR 
-  image: amd64/debian:bullseye
+  image: amd64/debian:bookworm-slim
   variables:
     OS: "debian"
   script:
@@ -21,7 +21,7 @@ build:debian:
 
 package:debian:
   stage: create-package-debian
-  image: amd64/debian:bullseye
+  image: amd64/debian:bookworm-slim
   artifacts:
    paths:
     - $CI_PROJECT_DIR 
@@ -50,7 +50,7 @@ package:debian:
 
 test:debian:
   stage: test-publish-debian
-  image: amd64/debian:bullseye
+  image: amd64/debian:bookworm-slim
   artifacts:
    name: builddebian
    paths:

--- a/gitlabci/debianlatest.yml
+++ b/gitlabci/debianlatest.yml
@@ -64,7 +64,7 @@ test:debian:
     - source $CI_PROJECT_DIR/scripts/debian_package/variables
     - echo $VFULL
     - apt update
-    - apt install -y openssl curl git lsb-release libevent-pthreads* libtommath* libpcre3 
+    - apt install -y openssl curl git lsb-release libevent-pthreads* libtommath* libpcre3 libssl1.3 
     - VERSION=`lsb_release -cs`
     - cd ${PACKDST} && dpkg -i e2"$OS"_package.deb 
     - sed -i "s/^#sslmitm.*$/sslmitm\ =\ on/" /etc/e2guardian/e2guardianf1.conf && sed -i "s/^#enablessl.*$/enablessl\ =\ on/" /etc/e2guardian/e2guardian.conf && sed -i "s/^RANDFILE\s*=\s*\\\$ENV/#RANDFILE\ =\ \$ENV/" /etc/ssl/openssl.cnf

--- a/gitlabci/debianlatest.yml
+++ b/gitlabci/debianlatest.yml
@@ -64,7 +64,7 @@ test:debian:
     - source $CI_PROJECT_DIR/scripts/debian_package/variables
     - echo $VFULL
     - apt update
-    - apt install -y openssl curl git lsb-release libevent-pthreads* libtommath* libpcre3 libssl1.3 
+    - apt install -y openssl curl git lsb-release libevent-pthreads* libtommath* libpcre3 libssl3 
     - VERSION=`lsb_release -cs`
     - cd ${PACKDST} && dpkg -i e2"$OS"_package.deb 
     - sed -i "s/^#sslmitm.*$/sslmitm\ =\ on/" /etc/e2guardian/e2guardianf1.conf && sed -i "s/^#enablessl.*$/enablessl\ =\ on/" /etc/e2guardian/e2guardian.conf && sed -i "s/^RANDFILE\s*=\s*\\\$ENV/#RANDFILE\ =\ \$ENV/" /etc/ssl/openssl.cnf

--- a/gitlabci/debianlatest.yml
+++ b/gitlabci/debianlatest.yml
@@ -23,6 +23,7 @@ package:debian:
   stage: create-package-debian
   image: amd64/debian:bookworm-slim
   artifacts:
+   expire_in: 30 minutes
    paths:
     - $CI_PROJECT_DIR 
   variables:
@@ -53,6 +54,7 @@ test:debian:
   image: amd64/debian:bookworm-slim
   artifacts:
    name: builddebian
+   expire_in: 30 minutes
    paths:
     - $CI_PROJECT_DIR 
   variables:

--- a/gitlabci/debianlatest.yml
+++ b/gitlabci/debianlatest.yml
@@ -30,7 +30,7 @@ package:debian:
     PACKDST: "$CI_PROJECT_DIR/scripts/debian_package/e2debian_package"
     OS: "debian"
   script:
-    - apt update && apt install --no-install-recommends --no-install-suggests -y curl git ca-certificates util-linux binutils
+    - apt update && apt install --no-install-recommends --no-install-suggests -y curl git ca-certificates util-linux binutils libpcre3 
     - git clone https://github.com/fredbcode/scripts
     - cp ${PACKPATH}/src/e2guardian ${PACKDST}/data/usr/sbin/e2guardian
     - chmod +x ${PACKDST}/data/usr/sbin/e2guardian      

--- a/gitlabci/debianlatest.yml
+++ b/gitlabci/debianlatest.yml
@@ -14,7 +14,7 @@ build:debian:
       bash coreutils dash debianutils diffutils dpkg e2fsprogs findutils grep gzip hostname ncurses-base
       libevent-pthreads-* libevent-dev ncurses-bin perl-base sed login sysvinit-utils tar bsdutils
       mount util-linux libc6-dev libc-dev gcc g++ make dpkg-dev autotools-dev debhelper dh-autoreconf dpatch
-      libclamav-dev libpcre3-dev zlib1g-dev pkg-config libssl-dev libssl1.1 git ca-certificates lsb-release
+      libclamav-dev libpcre3-dev zlib1g-dev pkg-config libssl-dev git ca-certificates lsb-release
     - cd $CI_PROJECT_DIR && ./autogen.sh && ./configure  '--prefix=/usr' '--enable-clamd=yes' '--with-proxyuser=e2guardian' '--with-proxygroup=e2guardian' '--sysconfdir=/etc' '--localstatedir=/var' '--enable-icap=yes' '--enable-commandline=yes' '--enable-email=yes' '--enable-ntlm=yes' '--mandir=${prefix}/share/man' '--infodir=${prefix}/share/info' '--enable-pcre=yes' '--enable-sslmitm=yes' 'CPPFLAGS=-mno-sse2 -g -O2'
     - make
     - find $CI_PROJECT_DIR -name ".git" -exec rm -r "{}" +

--- a/gitlabci/docker-ci/Dockerfile
+++ b/gitlabci/docker-ci/Dockerfile
@@ -10,7 +10,7 @@ COPY --from=builddocker --chown=1161 $DOCKER_BUILD/etc/e2guardian /etc/e2guardia
 COPY --from=builddocker --chown=1161 $DOCKER_BUILD/usr/share/e2guardian/languages /usr/share/e2guardian/languages
 COPY --from=builddocker --chown=1161 $DOCKER_BUILD/usr/share/e2guardian/*swf /usr/share/e2guardian/
 COPY --from=builddocker --chown=1161 $DOCKER_BUILD/usr/share/e2guardian/*gif /usr/share/e2guardian/
-RUN apt-get update && apt-get install --no-upgrade --no-install-recommends --no-install-suggests -y rsync sed libevent-pthreads-* libssl1.1 ca-certificates curl inotify-tools \
+RUN apt-get update && apt-get install --no-upgrade --no-install-recommends --no-install-suggests -y rsync sed libevent-pthreads-* ca-certificates curl inotify-tools \
     && adduser --no-create-home --uid 1161 --group --system e2guardian \
     && mkdir -p /run/e2guardian \
     && mkdir -p /var/log/e2guardian && chown -R e2guardian /var/log/e2guardian && chown -R e2guardian /run/e2guardian \

--- a/gitlabci/docker-ci/Dockerfile
+++ b/gitlabci/docker-ci/Dockerfile
@@ -10,7 +10,7 @@ COPY --from=builddocker --chown=1161 $DOCKER_BUILD/etc/e2guardian /etc/e2guardia
 COPY --from=builddocker --chown=1161 $DOCKER_BUILD/usr/share/e2guardian/languages /usr/share/e2guardian/languages
 COPY --from=builddocker --chown=1161 $DOCKER_BUILD/usr/share/e2guardian/*swf /usr/share/e2guardian/
 COPY --from=builddocker --chown=1161 $DOCKER_BUILD/usr/share/e2guardian/*gif /usr/share/e2guardian/
-RUN apt-get update && apt-get install --no-upgrade --no-install-recommends --no-install-suggests -y rsync sed libevent-pthreads-* ca-certificates curl inotify-tools libpcre3 libssl1.3 \
+RUN apt-get update && apt-get install --no-upgrade --no-install-recommends --no-install-suggests -y rsync sed libevent-pthreads-* ca-certificates curl inotify-tools libpcre3 libssl3 \
     && adduser --no-create-home --uid 1161 --group --system e2guardian \
     && mkdir -p /run/e2guardian \
     && mkdir -p /var/log/e2guardian && chown -R e2guardian /var/log/e2guardian && chown -R e2guardian /run/e2guardian \

--- a/gitlabci/docker-ci/Dockerfile
+++ b/gitlabci/docker-ci/Dockerfile
@@ -1,8 +1,8 @@
-FROM debian:bullseye-slim as builddocker
+FROM debian:bookworm-slim as builddocker
 ARG PROJECT_DIR
 COPY . /tmp/e2guardian
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 ARG PROJECT_DIR
 ENV DOCKER_BUILD=/tmp/e2guardian/scripts/debian_package/e2debian_package/data
 COPY --from=builddocker --chown=1161 /tmp/e2guardian/src/e2guardian /usr/sbin/e2guardian

--- a/gitlabci/docker-ci/Dockerfile
+++ b/gitlabci/docker-ci/Dockerfile
@@ -10,7 +10,7 @@ COPY --from=builddocker --chown=1161 $DOCKER_BUILD/etc/e2guardian /etc/e2guardia
 COPY --from=builddocker --chown=1161 $DOCKER_BUILD/usr/share/e2guardian/languages /usr/share/e2guardian/languages
 COPY --from=builddocker --chown=1161 $DOCKER_BUILD/usr/share/e2guardian/*swf /usr/share/e2guardian/
 COPY --from=builddocker --chown=1161 $DOCKER_BUILD/usr/share/e2guardian/*gif /usr/share/e2guardian/
-RUN apt-get update && apt-get install --no-upgrade --no-install-recommends --no-install-suggests -y rsync sed libevent-pthreads-* ca-certificates curl inotify-tools \
+RUN apt-get update && apt-get install --no-upgrade --no-install-recommends --no-install-suggests -y rsync sed libevent-pthreads-* ca-certificates curl inotify-tools libpcre3 libssl1.3 \
     && adduser --no-create-home --uid 1161 --group --system e2guardian \
     && mkdir -p /run/e2guardian \
     && mkdir -p /var/log/e2guardian && chown -R e2guardian /var/log/e2guardian && chown -R e2guardian /run/e2guardian \

--- a/gitlabci/ubuntufocal.yml
+++ b/gitlabci/ubuntufocal.yml
@@ -25,6 +25,7 @@ package:focal:
   dependencies:
     - build:focal
   artifacts:
+   expire_in: 30 minutes
    paths:
     - $CI_PROJECT_DIR
   variables:
@@ -58,6 +59,7 @@ test:focal:
   dependencies:
     - package:focal
   artifacts:
+   expire_in: 30 minutes
    paths:
     - $CI_PROJECT_DIR
   variables:

--- a/gitlabci/ubuntujammy.yml
+++ b/gitlabci/ubuntujammy.yml
@@ -25,6 +25,7 @@ package:jammy:
   dependencies:
     - build:jammy
   artifacts:
+   expire_in: 30 minutes
    paths:
     - $CI_PROJECT_DIR  
   variables:
@@ -59,6 +60,7 @@ test:jammy:
   dependencies:
     - package:jammy
   artifacts:
+   expire_in: 30 minutes
    paths:
     - $CI_PROJECT_DIR 
   variables:
@@ -93,4 +95,3 @@ test:jammy:
     - ssh-add <(echo "$SSH_NOSTROMO_KEY")
     - scp -P 822 -r ${CI_COMMIT_BRANCH} e2git@e2guardian.numsys.eu:/datas/e2/html 
     - find $CI_PROJECT_DIR -name ".git" -exec rm -r "{}" +
-     


### PR DESCRIPTION
Hi Philip

Here an upgrade to Debian 12 bookworm-slim for docker https://hub.docker.com/r/fredbcode/e2guardian and packages https://e2guardian.numsys.eu, this changes should be applied to all the recent branches

FYI: I saw some warnings in auto-build, for instance https://gitlab.com/fredbcode/e2guardian/-/jobs/5883562690#L1152  
 