### PR TITLE
{configs/e2guardian.conf.in,src/OptionContainer.cpp}: Make sure value…

### DIFF
--- a/configs/e2guardian.conf.in
+++ b/configs/e2guardian.conf.in
@@ -1103,7 +1103,7 @@ weightedphrasemode = 2
 # The size is in Kibibytes - eg 2048 = 2Mb
 # default 2048
 
-#maxcontentramcachescansize = 2000
+#maxcontentramcachescansize = 2048
 #
 # Max content ram cache scan size
 # This is only used if you use a content scanner plugin such as AV
@@ -1113,7 +1113,7 @@ weightedphrasemode = 2
 # The size is in Kibibytes - eg 10240 = 10Mb
 # use 0 to set it to maxcontentfilecachescansize
 # This option may be ignored by the configured download manager.
-# default 2000
+# default 2048
 
 #maxcontentfilecachescansize = 20000
 #

--- a/src/OptionContainer.cpp
+++ b/src/OptionContainer.cpp
@@ -372,7 +372,7 @@ bool OptionContainer::findContentScannerOptions(ConfigReader &cr)
     content.max_content_filecache_scan_size = cr.findoptionIWithDefault("maxcontentfilecachescansize", 0, 0, 20000);
     content.max_content_filecache_scan_size *= 1024;
 
-    content.max_content_ramcache_scan_size = cr.findoptionIWithDefault("maxcontentramcachescansize", 0, 0, 2000);
+    content.max_content_ramcache_scan_size = cr.findoptionIWithDefault("maxcontentramcachescansize", 0, 0, 2048);
     content.max_content_ramcache_scan_size *= 1024;
     if (content.max_content_ramcache_scan_size == 0) {
         content.max_content_ramcache_scan_size = content.max_content_filecache_scan_size;


### PR DESCRIPTION
…s of maxcontentfiltersize and maxcontentramcachesize obey to the requirements in the (inline) documentation.

 See Debian bug https://bugs.debian.org/998430 (which is a little hard to
 read, but the reported issue could be confirmed).
 .
 This change got lost on e2guardian's v5.5 branch, but is applied in
 similar form to the v5.4 branch. So, this basically is a regression fix.