### PR TITLE
Fix Logger build error #804

### DIFF
--- a/src/Logger.hpp
+++ b/src/Logger.hpp
@@ -15,6 +15,12 @@
 #include <fstream>
 #include <sstream>
 #include <cstdio>
+#ifdef stdout
+#undef stdout
+#endif
+#ifdef stderr
+#undef stderr
+#endif
 #include <atomic>
 #include <syslog.h>
 #include <unistd.h>


### PR DESCRIPTION
src/Logger.hpp includes <cstdio> which defines the macros stdout and stderr https://en.cppreference.com/w/cpp/io/c/std_streams and then uses those sames names in
enum class LoggerDestination { ... stdout, stderr, ... }

Luckily those macros are not used in e.g., a call to std::fprintf so just undefining them before use fixes the build.